### PR TITLE
adding await also to gentoo_src.initialize

### DIFF
--- a/bin/merge-gentoo-staging
+++ b/bin/merge-gentoo-staging
@@ -14,10 +14,10 @@ async def gentoo_staging_update():
 	await gentoo_staging_w.initialize()
 	#gentoo_src = mu.GitTree("gentoo-x86", "master", "https://github.com/gentoo/gentoo.git", pull=True)
 	gentoo_src = mu.GitTree("gentoo-x86", "master", "https://anongit.gentoo.org/git/repo/gentoo.git")
-	gentoo_src.initialize()
+	await gentoo_src.initialize()
 	#gentoo_src = CvsTree("gentoo-x86",":pserver:anonymous@anoncvs.gentoo.org:/var/cvsroot")
 	gentoo_glsa = mu.GitTree("gentoo-glsa", "master", "git://anongit.gentoo.org/data/glsa.git")
-	gentoo_glsa.initialize()
+	await gentoo_glsa.initialize()
 	# This is the gentoo-staging tree, stored in a different place locally, so we can simultaneously be updating gentoo-staging and reading
 	# from it without overwriting ourselves:
 


### PR DESCRIPTION
because if src dir empty it ends with an error:

```
./bin/merge-gentoo-staging
./bin/merge-gentoo-staging:17: RuntimeWarning: coroutine 'GitTree.initialize' was never awaited
  gentoo_src.initialize()
./bin/merge-gentoo-staging:20: RuntimeWarning: coroutine 'GitTree.initialize' was never awaited
  gentoo_glsa.initialize()
Running step GitCheckout <merge.merge_utils.GitCheckout object at 0x7f7a138d9898>
Running step SyncFromTree <merge.merge_utils.SyncFromTree object at 0x7f7a138d97f0>
/root/merge-scripts/modules/merge/merge_utils.py:1636: RuntimeWarning: coroutine 'SyncDir.run' was never awaited
  SyncDir.run(self,desttree)
Running step SyncDir <merge.merge_utils.SyncDir object at 0x7f7a138d9860>
Traceback (most recent call last):
  File "./bin/merge-gentoo-staging", line 37, in <module>
    loop.run_until_complete(gentoo_staging_update())
  File "/usr/lib64/python3.6/asyncio/base_events.py", line 468, in run_until_complete
    return future.result()
  File "./bin/merge-gentoo-staging", line 31, in gentoo_staging_update
    await gentoo_staging_w.run(all_steps)
  File "/root/merge-scripts/modules/merge/merge_utils.py", line 232, in run
    await step.run(self)
  File "/root/merge-scripts/modules/merge/merge_utils.py", line 1523, in run
    src = os.path.normpath(self.srcroot)+"/"
  File "/usr/lib/python-exec/python3.6/../../../lib64/python3.6/posixpath.py", line 333, in normpath
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not NoneType
sys:1: RuntimeWarning: coroutine 'GitTree.initialize_tree' was never awaited
```